### PR TITLE
Connect backend to Neon PostgreSQL and fix lint issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -444,3 +444,4 @@ dist-ssr
 
 # env files (can opt-in for committing if needed)
 .env*
+!front-tcc/.env.example

--- a/back-tcc/Data/ApplicationDbContext.cs
+++ b/back-tcc/Data/ApplicationDbContext.cs
@@ -7,4 +7,5 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     : DbContext(options)
 {
     public DbSet<Product> Products => Set<Product>();
+    public DbSet<Stock> Stocks => Set<Stock>();
 }

--- a/back-tcc/Models/Product.cs
+++ b/back-tcc/Models/Product.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace back_tcc.Models;
 
@@ -9,21 +10,27 @@ public enum ProductAvailability
     ForaDeEstoque
 }
 
+[Table("Produto")]
 public class Product
 {
-    public int Id { get; set; }
+    [Key]
+    public Guid Id { get; set; }
 
-    [Required]
+    [Column("Nome"), Required]
     public string Name { get; set; } = string.Empty;
 
-    [Required]
+    [Column("Categoria"), Required]
     public string Category { get; set; } = string.Empty;
 
-    [Range(0, double.MaxValue)]
+    [Column("Preco"), Range(0, double.MaxValue)]
     public decimal Price { get; set; }
 
-    [Range(0, int.MaxValue)]
+    [Column("Ativo")]
+    public bool Ativo { get; set; } = true;
+
+    [NotMapped]
     public int StockQuantity { get; set; }
 
+    [NotMapped]
     public ProductAvailability Availability { get; set; }
 }

--- a/back-tcc/Models/Stock.cs
+++ b/back-tcc/Models/Stock.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace back_tcc.Models;
+
+[Table("Estoque")]
+public class Stock
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    public Guid ProdutoId { get; set; }
+
+    public int Quantidade { get; set; }
+
+    public int MinimoAlerta { get; set; }
+
+    public DateTime AtualizadoEm { get; set; }
+}

--- a/back-tcc/Program.cs
+++ b/back-tcc/Program.cs
@@ -1,13 +1,26 @@
 using back_tcc.Data;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddOpenApi();
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseInMemoryDatabase("RestaurantDb"));
-builder.Services.AddControllers();
+    options.UseNpgsql(connectionString));
+builder.Services
+    .AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowFrontend", policy =>
+        policy.WithOrigins("http://localhost:8080")
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
 
 var app = builder.Build();
 
@@ -18,6 +31,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors("AllowFrontend");
 
 app.MapControllers();
 

--- a/back-tcc/appsettings.Development.json
+++ b/back-tcc/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=ep-divine-flower-acceamqw-pooler.sa-east-1.aws.neon.tech; Database=neondb; Username=neondb_owner; Password=npg_UQN23cpdDOGn; SSL Mode=VerifyFull; Channel Binding=Require;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/back-tcc/appsettings.json
+++ b/back-tcc/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=ep-divine-flower-acceamqw-pooler.sa-east-1.aws.neon.tech; Database=neondb; Username=neondb_owner; Password=npg_UQN23cpdDOGn; SSL Mode=VerifyFull; Channel Binding=Require;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/back-tcc/back-tcc.csproj
+++ b/back-tcc/back-tcc.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/front-tcc/.env.example
+++ b/front-tcc/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5125

--- a/front-tcc/README.md
+++ b/front-tcc/README.md
@@ -20,6 +20,8 @@ npm i
 npm run dev
 ```
 
+Para que o front-end se comunique com o back-end, crie um arquivo `.env` baseado em `.env.example` e ajuste a variável `VITE_API_URL` conforme a URL da API.
+
 ## Quais tecnologias são utilizadas neste projeto?
 
 Este projeto é construído com:

--- a/front-tcc/src/components/ui/command.tsx
+++ b/front-tcc/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/front-tcc/src/components/ui/textarea.tsx
+++ b/front-tcc/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/front-tcc/src/lib/api.ts
+++ b/front-tcc/src/lib/api.ts
@@ -1,0 +1,9 @@
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5125";
+
+export async function fetchProducts() {
+  const res = await fetch(`${API_URL}/api/products`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch products");
+  }
+  return res.json();
+}

--- a/front-tcc/src/pages/Produtos.tsx
+++ b/front-tcc/src/pages/Produtos.tsx
@@ -1,50 +1,40 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Plus, Search, Edit, Trash2 } from "lucide-react";
+import { fetchProducts } from "@/lib/api";
 
-const mockProducts = [
-  { 
-    id: 1, 
-    nome: "Tomates", 
-    categoria: "Complementos", 
-    preco: "R$ 8,50", 
-    estoque: 10, 
-    status: "Em estoque" 
-  },
-  { 
-    id: 2, 
-    nome: "Frango", 
-    categoria: "Carnes", 
-    preco: "R$ 25,00", 
-    estoque: 5, 
-    status: "Em estoque" 
-  },
-  { 
-    id: 3, 
-    nome: "Coca", 
-    categoria: "Bebidas", 
-    preco: "R$ 6,00", 
-    estoque: 0, 
-    status: "Fora de estoque" 
-  },
-];
+interface Product {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  stockQuantity: number;
+  availability: "EmEstoque" | "BaixoEstoque" | "ForaDeEstoque";
+}
 
 export const Produtos = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("");
   const [stockFilter, setStockFilter] = useState("");
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    fetchProducts()
+      .then(setProducts)
+      .catch((err) => console.error("Erro ao buscar produtos", err));
+  }, []);
 
   const getStatusBadge = (status: string) => {
     switch (status) {
-      case "Em estoque":
+      case "EmEstoque":
         return <Badge className="status-success">Em estoque</Badge>;
-      case "Baixo estoque":
+      case "BaixoEstoque":
         return <Badge className="status-warning">Baixo estoque</Badge>;
-      case "Fora de estoque":
+      case "ForaDeEstoque":
         return <Badge className="status-error">Fora de estoque</Badge>;
       default:
         return <Badge variant="secondary">{status}</Badge>;
@@ -134,13 +124,20 @@ export const Produtos = () => {
                 </tr>
               </thead>
               <tbody>
-                {mockProducts.map((product) => (
+                {products.map((product) => (
                   <tr key={product.id} className="border-b border-border hover:bg-muted/50">
-                    <td className="py-4 px-4 font-medium">{product.nome}</td>
-                    <td className="py-4 px-4 text-primary">{product.categoria}</td>
-                    <td className="py-4 px-4">{product.preco}</td>
-                    <td className="py-4 px-4">{product.estoque} uni</td>
-                    <td className="py-4 px-4">{getStatusBadge(product.status)}</td>
+                    <td className="py-4 px-4 font-medium">{product.name}</td>
+                    <td className="py-4 px-4 text-primary">{product.category}</td>
+                    <td className="py-4 px-4">
+                      {product.price.toLocaleString("pt-BR", {
+                        style: "currency",
+                        currency: "BRL",
+                      })}
+                    </td>
+                    <td className="py-4 px-4">{product.stockQuantity} uni</td>
+                    <td className="py-4 px-4">
+                      {getStatusBadge(product.availability)}
+                    </td>
                     <td className="py-4 px-4">
                       <div className="flex gap-2">
                         <Button variant="ghost" size="sm" className="text-primary hover:text-primary-hover">
@@ -161,13 +158,13 @@ export const Produtos = () => {
 
       {/* Products Cards - Mobile */}
       <div className="md:hidden space-y-4">
-        {mockProducts.map((product) => (
+        {products.map((product) => (
           <Card key={product.id} className="dashboard-card">
             <CardContent className="p-4">
               <div className="flex justify-between items-start mb-3">
                 <div>
-                  <h3 className="font-medium text-lg">{product.nome}</h3>
-                  <p className="text-primary text-sm">{product.categoria}</p>
+                  <h3 className="font-medium text-lg">{product.name}</h3>
+                  <p className="text-primary text-sm">{product.category}</p>
                 </div>
                 <div className="flex gap-2">
                   <Button variant="ghost" size="sm" className="text-primary hover:text-primary-hover">
@@ -181,15 +178,20 @@ export const Produtos = () => {
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div>
                   <span className="text-muted-foreground">Preço:</span>
-                  <p className="font-medium">{product.preco}</p>
+                  <p className="font-medium">
+                    {product.price.toLocaleString("pt-BR", {
+                      style: "currency",
+                      currency: "BRL",
+                    })}
+                  </p>
                 </div>
                 <div>
                   <span className="text-muted-foreground">Estoque:</span>
-                  <p className="font-medium">{product.estoque} uni</p>
+                  <p className="font-medium">{product.stockQuantity} uni</p>
                 </div>
               </div>
               <div className="mt-3">
-                {getStatusBadge(product.status)}
+                {getStatusBadge(product.availability)}
               </div>
             </CardContent>
           </Card>

--- a/front-tcc/tailwind.config.ts
+++ b/front-tcc/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -114,5 +115,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Use Npgsql-formatted Neon connection string in backend configs
- Replace empty interface in textarea component with a type alias to satisfy ESLint

## Testing
- `dotnet build back-tcc` *(fails: command not found)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beef995a20832598b0834c9e4e0990