### PR TITLE
Configure C# serverless function for Vercel

### DIFF
--- a/api/Function.cs
+++ b/api/Function.cs
@@ -1,0 +1,14 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public class Function
+{
+    public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, ILogger log)
+    {
+        log.LogInformation("C# HTTP trigger function processed a request.");
+        return req.CreateResponse(HttpStatusCode.OK, "Hello from .NET on Vercel!");
+    }
+}
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/*.cs",
+      "use": "@vercel/csharp"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/$1.cs"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a sample C# serverless function responding to HTTP requests
- configure Vercel to build C# files in `api/` with `@vercel/csharp` and route `/api/*` requests

## Testing
- `npm test` (fails: Could not read package.json)
- `dotnet build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1f9ba4c5483259ab0a8a308dc3e95